### PR TITLE
v1 build

### DIFF
--- a/Freql.App/Freql.App.fsproj
+++ b/Freql.App/Freql.App.fsproj
@@ -2,8 +2,8 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+        <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Freql.App/Program.fs
+++ b/Freql.App/Program.fs
@@ -117,8 +117,8 @@ module MySqlActions =
 [<RequireQualifiedAccess>]
 module SqliteActions =
     
-    let generate (databaseName: string) (profile: GeneratorProfile) (qh: QueryHandler) =
-        SqliteMetadata.get qh
+    let generate (databaseName: string) (profile: GeneratorProfile) (ctx: SqliteContext) =
+        SqliteMetadata.get ctx
         |> SqliteCodeGeneration.generate profile
         
 
@@ -157,7 +157,7 @@ module GenerationActions =
                         try
                             printfn $"{dbc.ConnectionString}"
                             let context =
-                                QueryHandler.Connect dbc.ConnectionString
+                                SqliteContext.Connect dbc.ConnectionString
 
                             SqliteActions.generate dbc.Name p context
                             |> save p.OutputPath

--- a/Freql.Core/Freql.Core.fsproj
+++ b/Freql.Core/Freql.Core.fsproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <WarnOn>3390;$(WarnOn)</WarnOn>
         <RepositoryUrl>https://github.com/mc738/Freql</RepositoryUrl>
         <Authors>Max Clifford</Authors>
         <PackageProjectUrl>https://github.com/mc738/Freql</PackageProjectUrl>
+        <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Freql.MySql.Tools/Freql.MySql.Tools.fsproj
+++ b/Freql.MySql.Tools/Freql.MySql.Tools.fsproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Freql.MySql/Freql.MySql.fsproj
+++ b/Freql.MySql/Freql.MySql.fsproj
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="MySql.Data" Version="8.0.26" />
+      <PackageReference Include="MySql.Data" Version="8.0.28" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Freql.MySql/Freql.MySql.fsproj
+++ b/Freql.MySql/Freql.MySql.fsproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <WarnOn>3390;$(WarnOn)</WarnOn>
         <RepositoryUrl>https://github.com/mc738/Freql</RepositoryUrl>
         <Authors>Max Clifford</Authors>
         <PackageProjectUrl>https://github.com/mc738/Freql</PackageProjectUrl>
+        <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Freql.MySql/Library.fs
+++ b/Freql.MySql/Library.fs
@@ -152,47 +152,6 @@ module private QueryHelpers =
         use reader = comm.ExecuteReader()
         mapper reader
 
-    
-    let create<'T> (tableName: string) connection transaction =
-        let mappedObj = MappedObject.Create<'T>()
-
-        let columns =
-            mappedObj.Fields
-            |> List.sortBy (fun p -> p.Index)
-            |> List.map
-                (fun f ->
-                    let template (colType: string) = $"{f.MappingName} {colType}"
-
-                    let blobField =
-                        $"{f.MappingName} BLOB, {f.MappingName}_sha256_hash TEXT"
-
-                    match f.Type with
-                    | SupportedType.Boolean -> template "INTEGER"
-                    | SupportedType.Byte -> template "INTEGER"
-                    | SupportedType.Int -> template "INTEGER"
-                    | SupportedType.Short -> template "INTEGER"
-                    | SupportedType.Long -> template "INTEGER"
-                    | SupportedType.Double -> template "REAL"
-                    | SupportedType.Float -> template "REAL"
-                    | SupportedType.Decimal -> template "REAL"
-                    | SupportedType.Char -> template "TEXT"
-                    | SupportedType.String -> template "TEXT"
-                    | SupportedType.DateTime -> template "TEXT"
-                    | SupportedType.Guid -> template "TEXT"
-                    | SupportedType.Blob -> template "BLOB")
-        //| SupportedType.Json -> template "BLOB")
-
-        let columnsString = System.String.Join(',', columns)
-
-        let sql =
-            $"""
-        CREATE TABLE {tableName} ({columnsString});
-        """
-
-        let comm = noParam connection sql transaction
-
-        comm.ExecuteNonQuery()
-
     let selectAll<'T> (tableName: string) connection transaction =
         let mappedObj = MappedObject.Create<'T>()
 
@@ -420,10 +379,6 @@ type MySqlContext(connection, transaction) =
         match List.isEmpty result with
         | true -> None
         | false -> Some result.Head
-
-    /// Execute a create table query based on a generic record. 
-    member handler.CreateTable<'T>(tableName: string) =
-        QueryHelpers.create<'T> tableName connection transaction
 
     /// Execute a raw sql non query. What is passed as a parameters is what will be executed.
     /// WARNING: do not used with untrusted input.

--- a/Freql.MySql/Library.fs
+++ b/Freql.MySql/Library.fs
@@ -442,4 +442,4 @@ type MySqlContext(connection, transaction) =
 
     /// Test the database connection.
     /// Useful for health checks.
-    member handler.TestConnection() = QueryHelpers.executeScalar<int64> "SELECT 1" connection transaction
+    member handler.TestConnection() = QueryHelpers.executeScalar<int> "SELECT 1" connection transaction

--- a/Freql.SqlServer/Freql.SqlServer.fsproj
+++ b/Freql.SqlServer/Freql.SqlServer.fsproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <WarnOn>3390;$(WarnOn)</WarnOn>
         <Authors>Max Clifford</Authors>
         <RepositoryUrl>https://github.com/mc738/Freql</RepositoryUrl>
         <PackageProjectUrl>https://github.com/mc738/Freql</PackageProjectUrl>
+        <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Freql.SqlServer/Freql.SqlServer.fsproj
+++ b/Freql.SqlServer/Freql.SqlServer.fsproj
@@ -18,7 +18,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+      <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
     </ItemGroup>
 
 </Project>

--- a/Freql.SqlServer/Library.fs
+++ b/Freql.SqlServer/Library.fs
@@ -103,46 +103,6 @@ module private QueryHelpers =
         let mappedObj = MappedObject.Create<'P>()
         let comm = prepare connection sql mappedObj parameters transaction
         comm.ExecuteNonQuery()
-    
-    let create<'T> (tableName: string) connection transaction =
-        let mappedObj = MappedObject.Create<'T>()
-
-        let columns =
-            mappedObj.Fields
-            |> List.sortBy (fun p -> p.Index)
-            |> List.map
-                (fun f ->
-                    let template (colType: string) = $"{f.MappingName} {colType}"
-
-                    let blobField =
-                        $"{f.MappingName} BLOB, {f.MappingName}_sha256_hash TEXT"
-
-                    match f.Type with
-                    | SupportedType.Boolean -> template "INTEGER"
-                    | SupportedType.Byte -> template "INTEGER"
-                    | SupportedType.Int -> template "INTEGER"
-                    | SupportedType.Short -> template "INTEGER"
-                    | SupportedType.Long -> template "INTEGER"
-                    | SupportedType.Double -> template "REAL"
-                    | SupportedType.Float -> template "REAL"
-                    | SupportedType.Decimal -> template "REAL"
-                    | SupportedType.Char -> template "TEXT"
-                    | SupportedType.String -> template "TEXT"
-                    | SupportedType.DateTime -> template "TEXT"
-                    | SupportedType.Guid -> template "TEXT"
-                    | SupportedType.Blob -> template "BLOB")
-        //| SupportedType.Json -> template "BLOB")
-
-        let columnsString = System.String.Join(',', columns)
-
-        let sql =
-            $"""
-        CREATE TABLE {tableName} ({columnsString});
-        """
-
-        let comm = noParam connection sql transaction
-
-        comm.ExecuteNonQuery()
 
     let selectAll<'T> (tableName: string) connection transaction =
         let mappedObj = MappedObject.Create<'T>()
@@ -186,9 +146,9 @@ module private QueryHelpers =
 
         mapResults<'T> tMappedObj reader
 
-    [<RequireQualifiedAccess>]
     /// Special handling is needed for `INSERT` query to accommodate blobs.
     /// This module aims to wrap as much of that up to in one place.
+    [<RequireQualifiedAccess>]
     module private Insert =
 
         type InsertBlobCallback = { ColumnName: string; Data: Stream }
@@ -300,10 +260,6 @@ type QueryHandler(connection, transaction) =
                 parameters
             )
             .Head
-
-    /// Execute a create table query based on a generic record.
-    member handler.CreateTable<'T>(tableName: string) =
-        QueryHelpers.create<'T> tableName connection transaction
 
     /// Execute a raw sql non query. What is passed as a parameters is what will be executed.
     /// WARNING: do not used with untrusted input.

--- a/Freql.Sqlite.Tools/Freql.Sqlite.Tools.fsproj
+++ b/Freql.Sqlite.Tools/Freql.Sqlite.Tools.fsproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Freql.Sqlite/Freql.Sqlite.fsproj
+++ b/Freql.Sqlite/Freql.Sqlite.fsproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <WarnOn>3390;$(WarnOn)</WarnOn>
         <RepositoryUrl>https://github.com/mc738/Freql</RepositoryUrl>
         <Authors>Max Clifford</Authors>
         <PackageProjectUrl>https://github.com/mc738/Freql</PackageProjectUrl>
+        <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Freql.Sqlite/Freql.Sqlite.fsproj
+++ b/Freql.Sqlite/Freql.Sqlite.fsproj
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.9" />
+      <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Freql.Sqlite/Library.fs
+++ b/Freql.Sqlite/Library.fs
@@ -416,7 +416,7 @@ type SqliteContext(connection: SqliteConnection, transaction: SqliteTransaction 
     /// <summary>
     /// Select data based on a verbatim sql and parameters of type 'P.
     /// Map the result to type 'T.
-    /// <summary>
+    /// </summary>
     /// <param name="sql">The sql query to be run</param>
     /// <param name="parameters">A record of type 'P representing query parameters.</param>
     /// <returns>A list of type 'T</returns>
@@ -439,7 +439,7 @@ type SqliteContext(connection: SqliteConnection, transaction: SqliteTransaction 
     /// This will return an optional value.
     /// Parameters will be assigned values @0,@1,@2 etc. based on their position in the list
     /// when the are parameterized.
-    /// <summary>
+    /// </summary>
     /// <param name="sql">The sql query to be run</param>
     /// <param name="parameters">A list of objects to be used are query parameters</param>
     /// <returns>An optional 'T</returns>
@@ -470,7 +470,7 @@ type SqliteContext(connection: SqliteConnection, transaction: SqliteTransaction 
     /// <summary>
     /// Select data based on a verbatim sql and parameters of type 'P.
     /// The first result is mapped to type 'T option.
-    /// <summary>
+    /// </summary>
     /// <param name="sql">The sql query to be run</param>
     /// <param name="parameters">A record of type 'P representing query parameters.</param>
     /// <returns>An optional 'T</returns>

--- a/Freql.TestConsole/Freql.TestConsole.fsproj
+++ b/Freql.TestConsole/Freql.TestConsole.fsproj
@@ -2,9 +2,9 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
         <WarnOn>3390;$(WarnOn)</WarnOn>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+        <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Freql.TestConsole/Program.fs
+++ b/Freql.TestConsole/Program.fs
@@ -45,18 +45,18 @@ let optionTest _ =
 	);
     """
 
-    let qh =
-        QueryHandler.Create("C:\\ProjectData\\OpenReferralUk\\delete-me.db")
+    let ctx =
+        SqliteContext.Create("C:\\ProjectData\\OpenReferralUk\\delete-me.db")
 
-    qh.ExecuteSqlNonQuery sql |> ignore
+    ctx.ExecuteSqlNonQuery sql |> ignore
 
     [ { Id = 1; Bar = Some "baz" }
       { Id = 2; Bar = None } ]
-    |> List.map (fun b -> qh.Insert("foo", b))
+    |> List.map (fun b -> ctx.Insert("foo", b))
     |> ignore
 
 
-    printfn "%A" (qh.Select<Foo>("foo"))
+    printfn "%A" (ctx.Select<Foo>("foo"))
 
     printfn "%A" (typeof<string option>.FullName |> get)
     printfn "%A" (typeof<int option>.FullName |> get)
@@ -190,10 +190,10 @@ let main argv =
     
     printfn "%A" constraints
     
-    let qh =
-        QueryHandler.Open("C:\\ProjectData\\Fiket\\prototypes\\workspace_v1.db")
+    let ctx =
+        SqliteContext.Open("C:\\ProjectData\\Fiket\\prototypes\\workspace_v1.db")
 
-    let dbd = Metadata.get qh
+    let dbd = Metadata.get ctx
 
     let gen =
         CodeGen.createRecords "Records" "My.Test.App" typeReplacements true dbd

--- a/Freql.Tools/DataStore.fs
+++ b/Freql.Tools/DataStore.fs
@@ -156,7 +156,7 @@ module Operations =
               DatabaseType = String.Empty
               CreatedOn = DateTime.UtcNow }
     
-    let insertDatabaseDefinition (parameters: AddDatabaseDefinitionParameters) (context: QueryHandler) =
+    let insertDatabaseDefinition (parameters: AddDatabaseDefinitionParameters) (context: SqliteContext) =
         context.Insert("database_definitions", parameters)
     
     type AddMetadataParameters =
@@ -175,7 +175,7 @@ module Operations =
               MetadataHash = String.Empty
               Verison = 0L }
     
-    let insertMetadata (parameters: AddMetadataParameters) (context: QueryHandler) =
+    let insertMetadata (parameters: AddMetadataParameters) (context: SqliteContext) =
         context.Insert("metadata", parameters)
     
     type AddMigrationParameters =
@@ -202,6 +202,6 @@ module Operations =
               FromReference = String.Empty
               ToReference = String.Empty }
     
-    let insertMigration (parameters: AddMigrationParameters) (context: QueryHandler) =
+    let insertMigration (parameters: AddMigrationParameters) (context: SqliteContext) =
         context.Insert("migrations", parameters)
     

--- a/Freql.Tools/Freql.Tools.fsproj
+++ b/Freql.Tools/Freql.Tools.fsproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This will be the basis over `v.1.0.0`. This will form release `v.0.5.0` and look to stabilise the API and remove obsolete code (such as `QueryHandler`).

## Breaking changes

1. Removal of `QueryHandler` from `Freql.Sqlite` (previously marked of obsolete)
    * Anything relying on this should stick on a previous version.
2. Removed `CreateTable` from `Freql.MySql` and `Freql.SqlServer`
    * Not really needed, I have never used them and you can't really create tables from in these databases from generics (for exmaple, all strings would be unlimited sized `varchars`). It most/all cases raw sql would be better.